### PR TITLE
Fix auth visibility logic in Header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -59,7 +59,8 @@ export default function Header() {
   }, [pathname]);
 
   const showNav = pathname === '/';
-  const showAuthControls = !['/login', '/signup'].includes(pathname);
+  const showAuthControls =
+    !pathname.startsWith('/login') && !pathname.startsWith('/signup');
 
   return (
     <header className="fixed inset-x-0 top-0 z-30 flex items-center justify-between px-6 py-4 backdrop-blur-md bg-black/30">


### PR DESCRIPTION
## Summary
- hide auth buttons for all login/signup routes

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841781a1360832aaa4b2781226ab998